### PR TITLE
Update README.md

### DIFF
--- a/authentication-with-auth0-and-apollo/README.md
+++ b/authentication-with-auth0-and-apollo/README.md
@@ -61,6 +61,7 @@ Go to the [Auth0 website](https://auth0.com/) and log into your Auth0 account. C
 Make sure to add `http://localhost:3000` to the _allowed callback URLs_ as well.
 
 Update **JsonWebToken Signature Algorithm** to `HS256` *(Clients > YOUR_CLIENT > Show Advanced Settings > OAuth)*.
+Disable **OIDC Conformant**
 
 ### 3.2 Configure Auth0 with Graphcool
 


### PR DESCRIPTION
Besides setting **JsonWebToken Signature Algorithm** to HS256, you also need to disable **OIDC Conformant** to make this example work. Might not be the safest though, I am not sure of the implications.