### PR TITLE
Fix typo in font-size for New Post

### DIFF
--- a/quickstart-with-apollo/src/components/ListPage.js
+++ b/quickstart-with-apollo/src/components/ListPage.js
@@ -34,7 +34,7 @@ class ListPage extends React.Component {
         <div className='w-100 flex flex-wrap' style={{maxWidth: 1150}}>
           <Link
             to='/create'
-            className='ma3 box new-post br2 flex flex-column items-center justify-center ttu fw6 f20 black-30 no-underline'
+            className='ma3 box new-post br2 flex flex-column items-center justify-center ttu fw6 f2 black-30 no-underline'
           >
             <img
               src={require('../assets/plus.svg')}


### PR DESCRIPTION
This is pretty small, but this is OSS so whatever.

For [the ListPage component in the “Quickstart with Apollo” example](https://github.com/graphcool-examples/react-graphql/blob/master/quickstart-with-apollo/src/components/ListPage.js#L37), I noticed a typo in a class name.

[There is no `f20` font-size in Tachyons](https://github.com/tachyons-css/tachyons/blob/master/src/_type-scale.css#L43-L49) so I presume this was meant to be `f2`? Otherwise, it should be deleted.

Thanks for the examples! They’re super helpful.