### PR TITLE
Fix typo in LoginUser for authentication-with-email-and-apollo example.

### DIFF
--- a/authentication-with-email-and-apollo/src/components/LoginUser.js
+++ b/authentication-with-email-and-apollo/src/components/LoginUser.js
@@ -11,7 +11,7 @@ class CreateLogin extends React.Component {
   }
 
   render () {
-    if (this.props.data.loading) {
+    if (this.props.loggedInUserQuery.loading) {
 
       return (
         <div className='w-100 pa4 flex justify-center'>
@@ -21,7 +21,7 @@ class CreateLogin extends React.Component {
     }
 
     // redirect if user is logged in
-    if (this.props.data.loggedInUser.id) {
+    if (this.props.loggedInUserQuery.loggedInUser.id) {
       console.warn('already logged in')
       this.props.history.replace('/')
     }


### PR DESCRIPTION
For **authentication-with-email-and-apollo** example

**Problem:**
When navigating to http://localhost:3000/login the following message is displayed.

```
  11 | }
  12 | 
  13 | render () {
> 14 |   if (this.props.data.loading) {
  15 | 
  16 |     return (
  17 |       <div className='w-100 pa4 flex justify-center'>
```

**Solution**
The CreateLogin component uses a named graphql query, so the response is passed to props with that name (`loggedInUserQuery`) instead of `data`. This PR replaces `this.props.data` with `this.props.loggedInUserQuery`.