### PR TITLE
Positioning fix for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Code examples & starter kits to see how React works with GraphQL and other technologies.
 
+<p align="center"><img src="http://imgur.com/G9mMBFT.png" /></p>
+
 <hr>
 
 **<p align="center">Select an example** from the list above to get started ⤴️</p>
 
 <hr>
-
-<p align="center"><img src="http://imgur.com/G9mMBFT.png" /></p>
 
 The examples above cover the following technologies:
 


### PR DESCRIPTION
Sentence reference to wrong location.

Sentence: "...from the list above to get started ⤴️"

Written "above" and icon shows arrow up, but
the mentioned list is under this sentence not above.
